### PR TITLE
Show correct name in riskfactors section of listing

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -933,8 +933,7 @@ function enhanceListingScreen(){
 
 		//risk factors
 		var loadriskfactors = function(){
-			var borrowername = user.alias;
-			// var borrowername = $("#body > div.ng-scope > div.row > div.col-sm-2 > div > p:nth-child(2) > a").text();
+			var borrowername = $(".user-img-listing").parent().next('p').children('a').text();
 			$.get($(".user-img-listing").parent().next('p').children('a').attr('href'), function(data){
 				$(data).find("#my_loans-table > tbody > tr").each(function (count, row){
 					var loanstatus = $(row).find('td:nth-child(7)').text().trim();


### PR DESCRIPTION
Great work on this extension man ....

Noticed a bug in the update. When viewing a listing, the risk factor section would show my name instead of the borrower's name in sections.

Couple of the affected statements ...
- Loan/Payment History for XXXX
- XXXX has not received any negative ratings!

I went with 

```
var borrowername = $(".user-img-listing").parent().next('p').children('a').text() 
```

instead of this line which was commented out:

```
var borrowername = $("#body > div.ng-scope > div.row > div.col-sm-2 > div > p:nth-child(2) > a").text();
```

Both pulled back the right answer, but since you were already depending on the $(".user-img-listing").parent().next('p').children('a') to work in line 937, I figured it would be best to only have a single  jQuery selector dependency. 

Let me know if you need me to change my approach.
