### PR TITLE
Updated the "Potential Return" formatting to match the "Total invested".

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -1735,7 +1735,7 @@ function calculatePotentialProfit(invested, rate, payments){
 	result.invested = invested;
 	result.rate = rate;
 	result.payments = payments;
-	result.total = 0.00000000;
+	result.total = parseFloat(0).toFixed(8);
 	result.profit = 0.00000000;
 
 	if(invested == 0){


### PR DESCRIPTION
When viewing a loan with zero investment, the "Potential Return" just displayed as 0.   At first glance, I thought the extension was throwing an error since previous versions formatted "Potential Return" to 8 decimal places.
